### PR TITLE
fix: vite esbuild should have public npm config

### DIFF
--- a/packages/vite-esbuild-plugin/package.json
+++ b/packages/vite-esbuild-plugin/package.json
@@ -15,5 +15,9 @@
     "@types/node": "^24.2.1",
     "esbuild": "^0.25.8",
     "typescript": "^5.9.2"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org",
+    "access": "public"
   }
 }


### PR DESCRIPTION
`@namada/vite-esbuild-plugin` needs a publish config with public access.

Published with fix:

https://www.npmjs.com/package/@namada/vite-esbuild-plugin